### PR TITLE
Invoices

### DIFF
--- a/src/docquery/ext/config.py
+++ b/src/docquery/ext/config.py
@@ -58,9 +58,12 @@ class LayoutLMTokenClassifierConfig(LayoutLMConfig):
         token_classification (`bool, *optional*, defaults to False):
             Whether to include an additional token classification head in question answering
         token_classifier_reduction (`str`, *optional*, defaults to "mean")
-            # TODO
+            Specifies the reduction to apply to the output of the cross entropy loss for the token classifier head during
+            training. Options are: 'none' | 'mean' | 'sum'. 'none': no reduction will be applied, 'mean': the weighted
+            mean of the output is taken, 'sum': the output will be summed.
         token_classifier_constant (`float`, *optional*, defaults to 1.0)
-            # TODO
+            Coefficient for the token classifier head's contribution to the total loss. A larger value means that the model
+            will prioritize learning the token classifier head during training.
     Examples:
     ```python
     >>> from transformers import LayoutLMModel, LayoutLMConfig

--- a/src/docquery/ext/config.py
+++ b/src/docquery/ext/config.py
@@ -20,15 +20,15 @@ class LayoutLMDocQueryConfig(LayoutLMConfig):
     model_type = "layoutlm-docquery"
 
     def __init__(
+        self,
         # New stuff added for DocQuery
         token_classification=False,
         token_classifier_reduction="mean",
         token_classifier_constant=1.0,
         **kwargs
     ):
-        super().__init__(
-            token_classification=token_classification,
-            token_classifier_reduction=token_classifier_reduction,
-            token_classifier_constant=token_classifier_constant,
-            **kwargs,
-        )
+        super().__init__(**kwargs)
+
+        self.token_classification = token_classification
+        self.token_classifier_reduction = token_classifier_reduction
+        self.token_classifier_constant = token_classifier_constant

--- a/src/docquery/ext/config.py
+++ b/src/docquery/ext/config.py
@@ -1,0 +1,34 @@
+# coding=utf-8
+# Copyright 2010, The Microsoft Research Asia LayoutLM Team authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" LayoutLM model configuration"""
+from transformers import LayoutLMConfig
+
+
+class LayoutLMDocQueryConfig(LayoutLMConfig):
+    model_type = "layoutlm-docquery"
+
+    def __init__(
+        # New stuff added for DocQuery
+        token_classification=False,
+        token_classifier_reduction="mean",
+        token_classifier_constant=1.0,
+        **kwargs
+    ):
+        super().__init__(
+            token_classification=token_classification,
+            token_classifier_reduction=token_classifier_reduction,
+            token_classifier_constant=token_classifier_constant,
+            **kwargs,
+        )

--- a/src/docquery/ext/config.py
+++ b/src/docquery/ext/config.py
@@ -17,6 +17,60 @@ from transformers import LayoutLMConfig
 
 
 class LayoutLMTokenClassifierConfig(LayoutLMConfig):
+    r"""
+    This is the configuration class to store the configuration of a [`LayoutLMModel`], extended to include token classification
+    constants. It is used to instantiate a LayoutLM model according to the specified arguments, defining the model architecture.
+    Instantiating a configuration with the defaults will yield a similar configuration to that of the LayoutLM
+    [microsoft/layoutlm-base-uncased](https://huggingface.co/microsoft/layoutlm-base-uncased) architecture.
+    Configuration objects inherit from [`BertConfig`] and can be used to control the model outputs. Read the
+    documentation from [`BertConfig`] for more information.
+    Args:
+        vocab_size (`int`, *optional*, defaults to 30522):
+            Vocabulary size of the LayoutLM model. Defines the different tokens that can be represented by the
+            *inputs_ids* passed to the forward method of [`LayoutLMModel`].
+        hidden_size (`int`, *optional*, defaults to 768):
+            Dimensionality of the encoder layers and the pooler layer.
+        num_hidden_layers (`int`, *optional*, defaults to 12):
+            Number of hidden layers in the Transformer encoder.
+        num_attention_heads (`int`, *optional*, defaults to 12):
+            Number of attention heads for each attention layer in the Transformer encoder.
+        intermediate_size (`int`, *optional*, defaults to 3072):
+            Dimensionality of the "intermediate" (i.e., feed-forward) layer in the Transformer encoder.
+        hidden_act (`str` or `function`, *optional*, defaults to `"gelu"`):
+            The non-linear activation function (function or string) in the encoder and pooler. If string, `"gelu"`,
+            `"relu"`, `"silu"` and `"gelu_new"` are supported.
+        hidden_dropout_prob (`float`, *optional*, defaults to 0.1):
+            The dropout probability for all fully connected layers in the embeddings, encoder, and pooler.
+        attention_probs_dropout_prob (`float`, *optional*, defaults to 0.1):
+            The dropout ratio for the attention probabilities.
+        max_position_embeddings (`int`, *optional*, defaults to 512):
+            The maximum sequence length that this model might ever be used with. Typically set this to something large
+            just in case (e.g., 512 or 1024 or 2048).
+        type_vocab_size (`int`, *optional*, defaults to 2):
+            The vocabulary size of the `token_type_ids` passed into [`LayoutLMModel`].
+        initializer_range (`float`, *optional*, defaults to 0.02):
+            The standard deviation of the truncated_normal_initializer for initializing all weight matrices.
+        layer_norm_eps (`float`, *optional*, defaults to 1e-12):
+            The epsilon used by the layer normalization layers.
+        max_2d_position_embeddings (`int`, *optional*, defaults to 1024):
+            The maximum value that the 2D position embedding might ever used. Typically set this to something large
+            just in case (e.g., 1024).
+        token_classification (`bool, *optional*, defaults to False):
+            Whether to include an additional token classification head in question answering
+        token_classifier_reduction (`str`, *optional*, defaults to "mean")
+            # TODO
+        token_classifier_constant (`float`, *optional*, defaults to 1.0)
+            # TODO
+    Examples:
+    ```python
+    >>> from transformers import LayoutLMModel, LayoutLMConfig
+    >>> # Initializing a LayoutLM configuration
+    >>> configuration = LayoutLMConfig()
+    >>> # Initializing a model from the configuration
+    >>> model = LayoutLMModel(configuration)
+    >>> # Accessing the model configuration
+    >>> configuration = model.config
+    ```"""
     model_type = "layoutlm-tc"
 
     def __init__(

--- a/src/docquery/ext/config.py
+++ b/src/docquery/ext/config.py
@@ -16,8 +16,8 @@
 from transformers import LayoutLMConfig
 
 
-class LayoutLMDocQueryConfig(LayoutLMConfig):
-    model_type = "layoutlm-docquery"
+class LayoutLMTokenClassifierConfig(LayoutLMConfig):
+    model_type = "layoutlm-tc"
 
     def __init__(
         self,

--- a/src/docquery/ext/itertools.py
+++ b/src/docquery/ext/itertools.py
@@ -1,0 +1,19 @@
+from itertools import filterfalse
+
+
+def unique_everseen(iterable, key=None):
+    "List unique elements, preserving order. Remember all elements ever seen."
+    # unique_everseen('AAAABBBCCDAABBB') --> A B C D
+    # unique_everseen('ABBCcAD', str.lower) --> A B C D
+    seen = set()
+    seen_add = seen.add
+    if key is None:
+        for element in filterfalse(seen.__contains__, iterable):
+            seen_add(element)
+            yield element
+    else:
+        for element in iterable:
+            k = key(element)
+            if k not in seen:
+                seen_add(k)
+                yield element

--- a/src/docquery/ext/itertools.py
+++ b/src/docquery/ext/itertools.py
@@ -1,14 +1,25 @@
-from itertools import filterfalse
+import itertools
 
 
 def unique_everseen(iterable, key=None):
-    "List unique elements, preserving order. Remember all elements ever seen."
-    # unique_everseen('AAAABBBCCDAABBB') --> A B C D
-    # unique_everseen('ABBCcAD', str.lower) --> A B C D
+    """
+    List unique elements, preserving order. Remember all elements ever seen [1]_.
+
+    Examples
+    --------
+    >>> list(unique_everseen("AAAABBBCCDAABBB"))
+    ["A", "B", "C", "D"]
+    >>> list(unique_everseen("ABBCcAD", str.lower))
+    ["A", "B", "C", "D"]
+
+    References
+    ----------
+    .. [1] https://docs.python.org/3/library/itertools.html
+    """
     seen = set()
     seen_add = seen.add
     if key is None:
-        for element in filterfalse(seen.__contains__, iterable):
+        for element in itertools.filterfalse(seen.__contains__, iterable):
             seen_add(element)
             yield element
     else:

--- a/src/docquery/ext/model.py
+++ b/src/docquery/ext/model.py
@@ -7,7 +7,7 @@ from torch.nn import CrossEntropyLoss, Linear
 from transformers import LayoutLMModel, LayoutLMPreTrainedModel
 from transformers.modeling_outputs import QuestionAnsweringModelOutput as QuestionAnsweringModelOutputBase
 
-from .config import LayoutLMConfig, LayoutLMDocQueryConfig
+from .config import LayoutLMConfig, LayoutLMTokenClassifierConfig
 
 
 @dataclass
@@ -15,8 +15,8 @@ class QuestionAnsweringModelOutput(QuestionAnsweringModelOutputBase):
     token_logits: Optional[torch.FloatTensor] = None
 
 
-class LayoutLMDocQueryForQuestionAnswering(LayoutLMPreTrainedModel):
-    config_class = LayoutLMDocQueryConfig
+class LayoutLMTokenClassifierForQuestionAnswering(LayoutLMPreTrainedModel):
+    config_class = LayoutLMTokenClassifierConfig
 
     def __init__(self, config, has_visual_segment_embedding=True):
         super().__init__(config)
@@ -185,10 +185,10 @@ class LayoutLMDocQueryForQuestionAnswering(LayoutLMPreTrainedModel):
         )
 
 
-# This is a thin wrapper around LayoutLMDocQueryForQuestionAnswering that simply instantiates
+# This is a thin wrapper around LayoutLMTokenClassifierForQuestionAnswering that simply instantiates
 # a default value for token_classification. Once we update transformers to be a version that
 # includes the upstremed LayoutLMForQuestionAnswering class, we can remove this.
-class LayoutLMForQuestionAnswering(LayoutLMDocQueryForQuestionAnswering):
+class LayoutLMForQuestionAnswering(LayoutLMTokenClassifierForQuestionAnswering):
     config_class = LayoutLMConfig
 
     def __init__(self, config, **kwargs):

--- a/src/docquery/ext/model.py
+++ b/src/docquery/ext/model.py
@@ -7,7 +7,7 @@ from torch.nn import CrossEntropyLoss, Linear
 from transformers import LayoutLMModel, LayoutLMPreTrainedModel
 from transformers.modeling_outputs import QuestionAnsweringModelOutput as QuestionAnsweringModelOutputBase
 
-from .config import LayoutLMDocQueryConfig
+from .config import LayoutLMConfig, LayoutLMDocQueryConfig
 
 
 @dataclass
@@ -149,7 +149,7 @@ class LayoutLMDocQueryForQuestionAnswering(LayoutLMPreTrainedModel):
             total_loss = (start_loss + end_loss) / 2
 
         token_logits = None
-        if self.token_classification:
+        if self.config.token_classification:
             token_logits = self.token_classifier_head(sequence_output)
 
             if token_labels is not None:
@@ -183,3 +183,14 @@ class LayoutLMDocQueryForQuestionAnswering(LayoutLMPreTrainedModel):
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,
         )
+
+
+# This is a thin wrapper around LayoutLMDocQueryForQuestionAnswering that simply instantiates
+# a default value for token_classification. Once we update transformers to be a version that
+# includes the upstremed LayoutLMForQuestionAnswering class, we can remove this.
+class LayoutLMForQuestionAnswering(LayoutLMDocQueryForQuestionAnswering):
+    config_class = LayoutLMConfig
+
+    def __init__(self, config, **kwargs):
+        config.token_classification = False
+        super().__init__(config, **kwargs)

--- a/src/docquery/ext/model.py
+++ b/src/docquery/ext/model.py
@@ -1,26 +1,33 @@
-# NOTE: This code is currently under review for inclusion in the main
-# huggingface/transformers repository:
-# https://github.com/huggingface/transformers/pull/18407
-""" PyTorch LayoutLM model."""
-
-
-import math
+from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
 import torch
 from torch import nn
-from torch.nn import CrossEntropyLoss
-from transformers.modeling_outputs import QuestionAnsweringModelOutput
-from transformers.models.layoutlm import LayoutLMModel, LayoutLMPreTrainedModel
+from torch.nn import CrossEntropyLoss, Linear
+from transformers import LayoutLMModel, LayoutLMPreTrainedModel
+from transformers.modeling_outputs import QuestionAnsweringModelOutput as QuestionAnsweringModelOutputBase
+
+from .config import LayoutLMDocQueryConfig
 
 
-class LayoutLMForQuestionAnswering(LayoutLMPreTrainedModel):
+@dataclass
+class QuestionAnsweringModelOutput(QuestionAnsweringModelOutputBase):
+    token_logits: Optional[torch.FloatTensor] = None
+
+
+class LayoutLMDocQueryForQuestionAnswering(LayoutLMPreTrainedModel):
+    config_class = LayoutLMDocQueryConfig
+
     def __init__(self, config, has_visual_segment_embedding=True):
         super().__init__(config)
         self.num_labels = config.num_labels
 
         self.layoutlm = LayoutLMModel(config)
         self.qa_outputs = nn.Linear(config.hidden_size, config.num_labels)
+
+        self.token_classifier_head = None
+        if self.config.token_classification:
+            self.token_classifier_head = Linear(config.hidden_size, 2)
 
         # Initialize weights and apply final processing
         self.post_init()
@@ -39,6 +46,7 @@ class LayoutLMForQuestionAnswering(LayoutLMPreTrainedModel):
         inputs_embeds: Optional[torch.FloatTensor] = None,
         start_positions: Optional[torch.LongTensor] = None,
         end_positions: Optional[torch.LongTensor] = None,
+        token_labels: Optional[torch.LongTensor] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
@@ -109,7 +117,14 @@ class LayoutLMForQuestionAnswering(LayoutLMPreTrainedModel):
             return_dict=return_dict,
         )
 
-        sequence_output = outputs[0]
+        if input_ids is not None:
+            input_shape = input_ids.size()
+        else:
+            input_shape = inputs_embeds.size()[:-1]
+
+        seq_length = input_shape[1]
+        # only take the text part of the output representations
+        sequence_output = outputs[0][:, :seq_length]
 
         logits = self.qa_outputs(sequence_output)
         start_logits, end_logits = logits.split(1, dim=-1)
@@ -133,14 +148,38 @@ class LayoutLMForQuestionAnswering(LayoutLMPreTrainedModel):
             end_loss = loss_fct(end_logits, end_positions)
             total_loss = (start_loss + end_loss) / 2
 
+        token_logits = None
+        if self.token_classification:
+            token_logits = self.token_classifier_head(sequence_output)
+
+            if token_labels is not None:
+                # Loss fn expects logits to be of shape (batch_size, num_labels, 512), but model
+                # outputs (batch_size, 512, num_labels), so we need to move the dimensions around
+                # Ref: https://pytorch.org/docs/stable/generated/torch.nn.CrossEntropyLoss.html
+                token_logits_reshaped = torch.movedim(token_logits, source=token_logits.ndim - 1, destination=1)
+                token_loss = CrossEntropyLoss(reduction=self.config.token_classifier_reduction)(
+                    token_logits_reshaped, token_labels
+                )
+
+                total_loss += self.config.token_classifier_constant * token_loss
+
         if not return_dict:
-            output = (start_logits, end_logits) + outputs[2:]
-            return ((total_loss,) + output) if total_loss is not None else output
+            output = (start_logits, end_logits)
+            if self.token_classification:
+                output = output + (token_logits,)
+
+            output = output + outputs[2:]
+
+            if total_loss is not None:
+                output = (total_loss,) + output
+
+            return output
 
         return QuestionAnsweringModelOutput(
             loss=total_loss,
             start_logits=start_logits,
             end_logits=end_logits,
+            token_logits=token_logits,
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,
         )

--- a/src/docquery/ext/pipeline.py
+++ b/src/docquery/ext/pipeline.py
@@ -187,11 +187,9 @@ class DocumentQuestionAnsweringPipeline(ChunkPipeline):
             A `dict` or a list of `dict`: Each result comes as a dictionary with the following keys:
 
             - **score** (`float`) -- The probability associated to the answer.
-            - **start** (`int`) -- The start word index of the answer (in the OCR'd version of the input or provided
-              `word_boxes`).
-            - **end** (`int`) -- The end word index of the answer (in the OCR'd version of the input or provided
-              `word_boxes`).
             - **answer** (`str`) -- The answer to the question.
+            - **words** (`list[int]`) -- The index of each word/box pair that is in the answer
+            - **page** (`int`) -- The page of the answer
         """
         if question is None:
             question = image["question"]
@@ -440,8 +438,8 @@ class DocumentQuestionAnsweringPipeline(ChunkPipeline):
                         {
                             "score": float(score),
                             "answer": " ".join(words[i] for i in answer_word_ids),
-                            "start": answer_word_ids[0],
-                            "end": answer_word_ids[-1],
+                            "words": answer_word_ids,
+                            # TODO: This is slightly inaccurate, since it is only the first page
                             "page": output["page"],
                         }
                     )

--- a/src/docquery/ext/pipeline.py
+++ b/src/docquery/ext/pipeline.py
@@ -439,7 +439,6 @@ class DocumentQuestionAnsweringPipeline(ChunkPipeline):
                             "score": float(score),
                             "answer": " ".join(words[i] for i in answer_word_ids),
                             "words": answer_word_ids,
-                            # TODO: This is slightly inaccurate, since it is only the first page
                             "page": output["page"],
                         }
                     )

--- a/src/docquery/ext/pipeline.py
+++ b/src/docquery/ext/pipeline.py
@@ -438,7 +438,7 @@ class DocumentQuestionAnsweringPipeline(ChunkPipeline):
                         {
                             "score": float(score),
                             "answer": " ".join(words[i] for i in answer_word_ids),
-                            "words": answer_word_ids,
+                            "word_ids": answer_word_ids,
                             "page": output["page"],
                         }
                     )

--- a/src/docquery/pipeline.py
+++ b/src/docquery/pipeline.py
@@ -6,8 +6,8 @@ from transformers.models.auto.auto_factory import _BaseAutoModelClass, _LazyAuto
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
 from transformers.pipelines import PIPELINE_REGISTRY
 
-from .ext.config import LayoutLMDocQueryConfig
-from .ext.model import LayoutLMDocQueryForQuestionAnswering
+from .ext.config import LayoutLMConfig, LayoutLMDocQueryConfig
+from .ext.model import LayoutLMDocQueryForQuestionAnswering, LayoutLMForQuestionAnswering
 from .ext.pipeline import DocumentQuestionAnsweringPipeline
 
 
@@ -16,6 +16,7 @@ REVISION = "3a93017fc2d200d68d0c2cc0fa62eb8d50314605"
 
 MODEL_FOR_DOCUMENT_QUESTION_ANSWERING_MAPPING_NAMES = OrderedDict(
     [
+        ("layoutlm", "LayoutLMForQuestionAnswering"),
         ("layoutlm-docquery", "LayoutLMDocQueryForQuestionAnswering"),
         ("donut-swin", "DonutSwinModel"),
     ]
@@ -54,7 +55,7 @@ def get_pipeline(checkpoint=None, revision=None, device=None):
 
     kwargs = {}
     if checkpoint == CHECKPOINT:
-        config = LayoutLMDocQueryConfig.from_pretrained(checkpoint, revision=revision)
+        config = LayoutLMConfig.from_pretrained(checkpoint, revision=revision)
         kwargs["add_prefix_space"] = True
     else:
         config = AutoConfig.from_pretrained(checkpoint, revision=revision)
@@ -67,7 +68,7 @@ def get_pipeline(checkpoint=None, revision=None, device=None):
     )
 
     if checkpoint == CHECKPOINT:
-        model = LayoutLMDocQueryForQuestionAnswering.from_pretrained(checkpoint, revision=revision)
+        model = LayoutLMForQuestionAnswering.from_pretrained(checkpoint, revision=revision)
     else:
         model = checkpoint
 

--- a/src/docquery/pipeline.py
+++ b/src/docquery/pipeline.py
@@ -1,13 +1,13 @@
 from collections import OrderedDict
 
 import torch
-from transformers import AutoConfig, AutoTokenizer, pipeline
+from transformers import AutoConfig, AutoModel, AutoTokenizer, pipeline
 from transformers.models.auto.auto_factory import _BaseAutoModelClass, _LazyAutoMapping
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
-from transformers.models.layoutlm.configuration_layoutlm import LayoutLMConfig
 from transformers.pipelines import PIPELINE_REGISTRY
 
-from .ext.model import LayoutLMForQuestionAnswering
+from .ext.config import LayoutLMDocQueryConfig
+from .ext.model import LayoutLMDocQueryForQuestionAnswering
 from .ext.pipeline import DocumentQuestionAnsweringPipeline
 
 
@@ -16,7 +16,7 @@ REVISION = "3a93017fc2d200d68d0c2cc0fa62eb8d50314605"
 
 MODEL_FOR_DOCUMENT_QUESTION_ANSWERING_MAPPING_NAMES = OrderedDict(
     [
-        ("layoutlm", "LayoutLMForQuestionAnswering"),
+        ("layoutlm-docquery", "LayoutLMDocQueryForQuestionAnswering"),
         ("donut-swin", "DonutSwinModel"),
     ]
 )
@@ -28,6 +28,11 @@ MODEL_FOR_DOCUMENT_QUESTION_ANSWERING_MAPPING = _LazyAutoMapping(
 
 class AutoModelForDocumentQuestionAnswering(_BaseAutoModelClass):
     _model_mapping = MODEL_FOR_DOCUMENT_QUESTION_ANSWERING_MAPPING
+
+
+AutoConfig.register("layoutlm-docquery", LayoutLMDocQueryConfig)
+AutoModel.register(LayoutLMDocQueryConfig, LayoutLMDocQueryForQuestionAnswering)
+AutoModelForDocumentQuestionAnswering.register(LayoutLMDocQueryConfig, LayoutLMDocQueryForQuestionAnswering)
 
 
 PIPELINE_REGISTRY.register_pipeline(
@@ -49,7 +54,7 @@ def get_pipeline(checkpoint=None, revision=None, device=None):
 
     kwargs = {}
     if checkpoint == CHECKPOINT:
-        config = LayoutLMConfig.from_pretrained(checkpoint, revision=revision)
+        config = LayoutLMDocQueryConfig.from_pretrained(checkpoint, revision=revision)
         kwargs["add_prefix_space"] = True
     else:
         config = AutoConfig.from_pretrained(checkpoint, revision=revision)
@@ -62,7 +67,7 @@ def get_pipeline(checkpoint=None, revision=None, device=None):
     )
 
     if checkpoint == CHECKPOINT:
-        model = LayoutLMForQuestionAnswering.from_pretrained(checkpoint, revision=revision)
+        model = LayoutLMDocQueryForQuestionAnswering.from_pretrained(checkpoint, revision=revision)
     else:
         model = checkpoint
 

--- a/src/docquery/pipeline.py
+++ b/src/docquery/pipeline.py
@@ -79,7 +79,9 @@ def get_pipeline(checkpoint=None, revision=None, device=None, **pipeline_kwargs)
     if config.model_type == "vision-encoder-decoder":
         pipeline_kwargs["feature_extractor"] = model
     elif config.model_type == "layoutlm-tc":
-        pipeline_kwargs["max_answer_len"] = 1000  # Let the token classifier filter things out
+        # Disable limiting the answer in `decode_spans` by setting `max_answer_len` to a value
+        # greater than or equal to the maximum number of tokens.
+        pipeline_kwargs["max_answer_len"] = tokenizer.model_max_length
 
     return pipeline(
         "document-question-answering",

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -37,8 +37,8 @@ EXAMPLES = [
             {
                 "question": "What is the purchase amount?",
                 "answers": {
-                    "LayoutLMv1": {"score": 0.9999, "answer": "$1,000,000,000", "words": [97], "page": 0},
-                    "LayoutLMv1-Invoices": {"score": 0.9997, "answer": "$1,000,000,000", "words": [97], "page": 0},
+                    "LayoutLMv1": {"score": 0.9999, "answer": "$1,000,000,000", "word_ids": [97], "page": 0},
+                    "LayoutLMv1-Invoices": {"score": 0.9997, "answer": "$1,000,000,000", "word_ids": [97], "page": 0},
                     "Donut": {"answer": "$1,0000,000,00"},
                 },
             }
@@ -51,8 +51,8 @@ EXAMPLES = [
             {
                 "question": "What is the invoice number?",
                 "answers": {
-                    "LayoutLMv1": {"score": 0.9997, "answer": "us-001", "words": [15], "page": 0},
-                    "LayoutLMv1-Invoices": {"score": 0.9999, "answer": "us-001", "words": [15], "page": 0},
+                    "LayoutLMv1": {"score": 0.9997, "answer": "us-001", "word_ids": [15], "page": 0},
+                    "LayoutLMv1-Invoices": {"score": 0.9999, "answer": "us-001", "word_ids": [15], "page": 0},
                     "Donut": {"answer": "us-001"},
                 },
             }
@@ -65,8 +65,8 @@ EXAMPLES = [
             {
                 "question": "What are net sales for 2020?",
                 "answers": {
-                    "LayoutLMv1": {"score": 0.9429, "answer": "$ 3,750\n", "words": [15, 16], "page": 0},
-                    "LayoutLMv1-Invoices": {"score": 0.9956, "answer": "$ 3,750\n", "words": [15, 16], "page": 0},
+                    "LayoutLMv1": {"score": 0.9429, "answer": "$ 3,750\n", "word_ids": [15, 16], "page": 0},
+                    "LayoutLMv1-Invoices": {"score": 0.9956, "answer": "$ 3,750\n", "word_ids": [15, 16], "page": 0},
                     "Donut": {"answer": "$ 3,750"},
                 },
             }

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -12,6 +12,7 @@ from docquery.pipeline import get_pipeline
 
 CHECKPOINTS = {
     "LayoutLMv1": "impira/layoutlm-document-qa",
+    "LayoutLMv1-Invoices": "impira/layoutlm-invoices",
     "Donut": "naver-clova-ix/donut-base-finetuned-docvqa",
 }
 
@@ -36,13 +37,8 @@ EXAMPLES = [
             {
                 "question": "What is the purchase amount?",
                 "answers": {
-                    "LayoutLMv1": {
-                        "score": 0.9999,
-                        "answer": "$1,000,000,000",
-                        "start": 97,
-                        "end": 97,
-                        "page": 0,
-                    },
+                    "LayoutLMv1": {"score": 0.9999, "answer": "$1,000,000,000", "words": [97], "page": 0},
+                    "LayoutLMv1-Invoices": {"score": 0.9997, "answer": "$1,000,000,000", "words": [97], "page": 0},
                     "Donut": {"answer": "$1,0000,000,00"},
                 },
             }
@@ -55,7 +51,8 @@ EXAMPLES = [
             {
                 "question": "What is the invoice number?",
                 "answers": {
-                    "LayoutLMv1": {"score": 0.9997, "answer": "us-001", "start": 15, "end": 15, "page": 0},
+                    "LayoutLMv1": {"score": 0.9997, "answer": "us-001", "words": [15], "page": 0},
+                    "LayoutLMv1-Invoices": {"score": 0.9999, "answer": "us-001", "words": [15], "page": 0},
                     "Donut": {"answer": "us-001"},
                 },
             }
@@ -68,13 +65,8 @@ EXAMPLES = [
             {
                 "question": "What are net sales for 2020?",
                 "answers": {
-                    "LayoutLMv1": {
-                        "score": 0.9429,
-                        "answer": "$ 3,750\n",
-                        "start": 15,
-                        "end": 16,
-                        "page": 0,
-                    },
+                    "LayoutLMv1": {"score": 0.9429, "answer": "$ 3,750\n", "words": [15, 16], "page": 0},
+                    "LayoutLMv1-Invoices": {"score": 0.9956, "answer": "$ 3,750\n", "words": [15, 16], "page": 0},
                     "Donut": {"answer": "$ 3,750"},
                 },
             }


### PR DESCRIPTION
This change introduces the token classification head as an option for `LayoutLMForQuestionAnswering`, which is leveraged by our new invoice models (but usable for any document type).

I did some refactoring, since we now reference a model that has a different model config type than `layoutlm`, and need to propagate word indices instead of just a start/end.