### PR TITLE
Add support for web scraping

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 119
-ignore = E402, E203, E501
+ignore = E402, E203, E501, W503

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ DocQuery is intended to have a small install footprint and be simple to work wit
 - Support for images and PDFs. Currently DocQuery supports images and PDFs, with or without embedded text. It does not support word documents, emails, spreadsheets, etc.
 - Scalar text outputs. DocQuery only produces text outputs (answers). It does not support richer scalar types (i.e. it treats numbers and dates as strings) or tables.
 
-## Using Donut 🍩
+## Advanced features
+
+### Using Donut 🍩
 
 If you'd like to test `docquery` with [Donut](https://arxiv.org/abs/2111.15664), you must install a special version of transformers:
 
@@ -97,7 +99,7 @@ since it has not yet been released in a tagged release. You can then run
 docquery scan "What is the effective date?" /path/to/contracts/folder --checkpoint 'naver-clova-ix/donut-base-finetuned-docvqa'
 ```
 
-## Classifying documents
+### Classifying documents
 
 To classify documents, you simply add the `--classify` argument to `scan`. You can specify any [image classification](https://huggingface.co/models?pipeline_tag=image-classification&sort=downloads)
 model on Hugging Face's hub. By default, the classification pipeline uses [Donut](https://huggingface.co/spaces/nielsr/donut-rvlcdip) (which requires
@@ -110,6 +112,17 @@ docquery scan --classify  /path/to/contracts/folder --checkpoint 'naver-clova-ix
 
 # Classify documents and ask a question too
 docquery scan --classify "What is the effective date?" /path/to/contracts/folder --checkpoint 'naver-clova-ix/donut-base-finetuned-docvqa'
+```
+
+### Scraping webpages
+
+DocQuery can read files through HTTP/HTTPs out of the box. However, if you want to read HTML documents, you can do that too by installing the
+`[web]` extension. The extension uses the [webdriver-manager](https://pypi.org/project/webdriver-manager/) library which can install a Chrome
+driver on your system automatically, but you'll need to make sure Chrome is installed globally.
+
+```
+# Find the top post on hacker news
+docquery scan "What is the #1 post's title?" https://news.ycombinator.com
 ```
 
 ## Where to go from here

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     package_dir={"": "src"},
+    package_data={"": ["find_leaf_nodes.js"]},
     packages=setuptools.find_packages(where="src"),
     python_requires=">=3.7.0",
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ extras_require = {
     ],
     "web": [
         "selenium",
-    ]
+        "webdriver-manager",
+    ],
     "cli": [],
 }
 extras_require["all"] = sorted({package for packages in extras_require.values() for package in packages})

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,9 @@ extras_require = {
         "sentencepiece",
         "protobuf<=3.20.1",
     ],
+    "web": [
+        "selenium",
+    ]
     "cli": [],
 }
 extras_require["all"] = sorted({package for packages in extras_require.values() for package in packages})

--- a/src/docquery/cmd/scan.py
+++ b/src/docquery/cmd/scan.py
@@ -82,7 +82,7 @@ def main(args):
                 if isinstance(response, list):
                     response = response[0] if len(response) > 0 else None
             except Exception:
-                log.error(f"Failed while processing {str(p)} on question {q}!")
+                log.error(f"Failed while processing {str(p)} on question: '{q}'")
                 raise
 
             answer = response["answer"] if response is not None else "NULL"

--- a/src/docquery/document.py
+++ b/src/docquery/document.py
@@ -1,4 +1,5 @@
 import abc
+import mimetypes
 import os
 from io import BytesIO
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -7,6 +8,7 @@ import requests
 from pydantic import validate_arguments
 
 from .ocr_reader import NoOCRReaderFound, OCRReader, get_ocr_reader
+from .web import get_webdriver
 
 
 try:
@@ -66,10 +68,6 @@ def use_pdf_plumber():
 
 
 class Document(metaclass=abc.ABCMeta):
-    def __init__(self, b, ocr_reader):
-        self.b = b
-        self.ocr_reader = ocr_reader
-
     @property
     @abc.abstractmethod
     def context(self) -> Tuple[(str, List[int])]:
@@ -121,6 +119,12 @@ class Document(metaclass=abc.ABCMeta):
 
 
 class PDFDocument(Document):
+    def __init__(self, b, ocr_reader, **kwargs):
+        self.b = b
+        self.ocr_reader = ocr_reader
+
+        super().__init__(**kwargs)
+
     @cached_property
     def context(self) -> Dict[str, List[Tuple["Image.Image", List[Any]]]]:
         pdf = self._pdf
@@ -178,6 +182,12 @@ class PDFDocument(Document):
 
 
 class ImageDocument(Document):
+    def __init__(self, b, ocr_reader, **kwargs):
+        self.b = b
+        self.ocr_reader = ocr_reader
+
+        super().__init__(**kwargs)
+
     @cached_property
     def preview(self) -> "Image":
         return [self.b.convert("RGB")]
@@ -188,27 +198,70 @@ class ImageDocument(Document):
         return self._generate_document_output([self.b], [words], [boxes], [(self.b.width, self.b.height)])
 
 
+class WebDocument(Document):
+    def __init__(self, url, **kwargs):
+        if not (url.startswith("http://") or url.startswith("https://")):
+            url = "file://" + url
+        self.url = url
+
+        # TODO: This is a singleton, which is not thread-safe. We may want to relax this
+        # behavior to allow the user to pass in their own driver (which could either be a
+        # singleton or a custom instance).
+        self.driver = get_webdriver()
+
+        super().__init__(**kwargs)
+
+    def ensure_loaded(self):
+        self.driver.get(self.url)
+
+    @cached_property
+    def preview(self) -> "Image":
+        self.ensure_loaded()
+        return [Image.open(BytesIO(img)).convert("RGB") for img in self.driver.screenshots_png()]
+
+    @cached_property
+    def context(self) -> Dict[str, List[Tuple["Image.Image", List[Any]]]]:
+        self.ensure_loaded()
+        word_boxes = self.driver.find_word_boxes()
+
+        # TODO: This assumes everything fits in a page, which is likely a bad assumption
+        words = []
+        boxes = []
+        for word_box in word_boxes["word_boxes"]:
+            words.append(word_box["text"])
+            box = word_box["box"]
+            boxes.append((box["left"], box["top"], box["right"], box["bottom"]))
+
+        return self._generate_document_output(
+            self.preview, [words], [boxes], [(word_boxes["width"], word_boxes["height"])]
+        )
+
+
 @validate_arguments
 def load_document(fpath: str, ocr_reader: Optional[Union[str, OCRReader]] = None):
+    base_path = os.path.basename(fpath).split("?")[0].strip()
+    doc_type = mimetypes.guess_type(base_path)
     if fpath.startswith("http://") or fpath.startswith("https://"):
-        resp = requests.get(fpath, stream=True)
+        resp = requests.get(fpath, allow_redirects=True, stream=True)
         if not resp.ok:
             raise UnsupportedDocument(f"Failed to download: {resp.content}")
+
+        if "Content-Type" in resp.headers:
+            doc_type = resp.headers["Content-Type"].split(";")[0].strip()
+
         b = resp.raw
     else:
         b = open(fpath, "rb")
-    return load_bytes(b, fpath, ocr_reader=ocr_reader)
 
-
-def load_bytes(b, fpath, ocr_reader: Optional[Union[str, Any]]):
     if not ocr_reader or isinstance(ocr_reader, str):
         ocr_reader = get_ocr_reader(ocr_reader)
     elif not isinstance(ocr_reader, OCRReader):
         raise NoOCRReaderFound(f"{ocr_reader} is not a supported OCRReader class")
 
-    extension = os.path.basename(fpath).rsplit(".", 1)[-1].split("?")[0].strip()
-    if extension in ("pdf"):
+    if doc_type == "application/pdf":
         return PDFDocument(b.read(), ocr_reader=ocr_reader)
+    elif doc_type == "text/html":
+        return WebDocument(fpath)
     else:
         use_pil()
         try:

--- a/src/docquery/document.py
+++ b/src/docquery/document.py
@@ -236,7 +236,7 @@ class WebDocument(Document):
 @validate_arguments
 def load_document(fpath: str, ocr_reader: Optional[Union[str, OCRReader]] = None):
     base_path = os.path.basename(fpath).split("?")[0].strip()
-    doc_type = mimetypes.guess_type(base_path)
+    doc_type = mimetypes.guess_type(base_path)[0]
     if fpath.startswith("http://") or fpath.startswith("https://"):
         resp = requests.get(fpath, allow_redirects=True, stream=True)
         if not resp.ok:

--- a/src/docquery/document.py
+++ b/src/docquery/document.py
@@ -211,7 +211,7 @@ class WebDocument(Document):
     @cached_property
     def page_screenshots(self):
         self.ensure_loaded()
-        return self.driver.screenshots_png()
+        return self.driver.scroll_and_screenshot()
 
     @cached_property
     def preview(self) -> "Image":
@@ -228,7 +228,6 @@ class WebDocument(Document):
         page = 0
         offset = 0
 
-        # TODO: This assumes everything fits in a page, which is likely a bad assumption
         words = [[] for _ in range(n_pages)]
         boxes = [[] for _ in range(n_pages)]
         for word_box in word_boxes["word_boxes"]:
@@ -241,6 +240,7 @@ class WebDocument(Document):
             words[page].append(word_box["text"])
             boxes[page].append((box["left"], box["top"] - offset, box["right"], box["bottom"] - offset))
 
+        # XXX Need to clip the last window in case there is overlap with the previous one
         return self._generate_document_output(
             self.preview, words, boxes, [(word_boxes["vw"], word_boxes["vh"])] * n_pages
         )

--- a/src/docquery/ext/functools.py
+++ b/src/docquery/ext/functools.py
@@ -1,0 +1,5 @@
+try:
+    from functools import cached_property as cached_property
+except ImportError:
+    # for python 3.7 support fall back to just property
+    cached_property = property

--- a/src/docquery/find_leaf_nodes.js
+++ b/src/docquery/find_leaf_nodes.js
@@ -1,0 +1,56 @@
+// https://stackoverflow.com/questions/4795473/check-visibility-of-an-object-with-javascript
+function isVisible(obj) {
+  return obj.offsetWidth > 0 && obj.offsetHeight > 0;
+}
+
+function findLeafNodes(node) {
+  if (!isVisible(node)) {
+    return [];
+  }
+
+  if (node.children.length == 0 && node.innerText.length > 0) {
+    return [node];
+  }
+
+  let children = [];
+  for (let i = 0; i < node.children.length; i++) {
+    children.push(...findLeafNodes(node.children[i]));
+  }
+
+  const childrenText = children.reduce(
+    (a, x) => a + x.innerText.replace(/\s/g, ""),
+    ""
+  );
+
+  // If the childrens' text contains all of the parent's text, return
+  // the children. Otherwise, return the parent. This is unlikely the
+  // most performant way to do this...
+  parentText = node.innerText.replace(/\s/g, "");
+
+  if (childrenText == parentText) {
+    return children;
+  } else {
+    return [node];
+  }
+}
+
+function computeBoundingBoxes(node) {
+  const vw = Math.max(
+    document.documentElement.clientWidth || 0,
+    window.innerWidth || 0
+  );
+  const vh = Math.max(
+    document.documentElement.clientHeight || 0,
+    window.innerHeight || 0
+  );
+
+  const leafNodes = findLeafNodes(node);
+  return {
+    width: vw,
+    height: vh,
+    word_boxes: leafNodes.map((n) => ({
+      text: n.innerText,
+      box: n.getBoundingClientRect().toJSON(),
+    })),
+  };
+}

--- a/src/docquery/web.py
+++ b/src/docquery/web.py
@@ -1,0 +1,33 @@
+import os
+from pathlib import Path
+
+from chromedriver_py import binary_path  # This library allows you to download the driver for your version of chrome
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+
+
+FIND_LEAF_NODES_JS = None
+dir_path = Path(os.path.dirname(os.path.realpath(__file__)))
+
+
+def get_webdriver():
+    options = Options()
+    options.headless = True
+    options.add_argument("--window-size=1920,1200")
+
+    return webdriver.Chrome(options=options, executable_path=binary_path)
+
+
+def find_word_boxes(driver):
+    global FIND_LEAF_NODES_JS
+    if FIND_LEAF_NODES_JS is None:
+        with open(dir_path / "find_leaf_nodes.js", "r") as f:
+            FIND_LEAF_NODES_JS = (
+                f.read()
+                + """
+                return computeBoundingBoxes(document.body);
+            """
+            )
+    # Assumes the driver has been pointed at the right website already
+    return driver.execute_script(FIND_LEAF_NODES_JS)

--- a/src/docquery/web.py
+++ b/src/docquery/web.py
@@ -11,11 +11,9 @@ from .ext.functools import cached_property
 log = get_logger("web")
 
 try:
-    from chromedriver_py import (  # This library allows you to download the driver for your version of chrome
-        binary_path,
-    )
     from selenium import webdriver
     from selenium.webdriver.chrome.options import Options
+    from webdriver_manager.chrome import ChromeDriverManager
 
     WEB_AVAILABLE = True
 except ImportError as e:
@@ -40,7 +38,7 @@ class WebDriver:
         options.headless = True
         options.add_argument("--window-size=1920,1200")
 
-        self.driver = webdriver.Chrome(options=options, executable_path=binary_path)
+        self.driver = webdriver.Chrome(options=options, executable_path=ChromeDriverManager().install())
 
     def get(self, page):
         self.driver.get(page)

--- a/src/docquery/web.py
+++ b/src/docquery/web.py
@@ -2,7 +2,7 @@ import os
 from io import BytesIO
 from pathlib import Path
 
-from PIL import Image, UnidentifiedImageError
+from PIL import Image
 
 from .config import get_logger
 from .ext.functools import cached_property

--- a/src/docquery/web.py
+++ b/src/docquery/web.py
@@ -56,7 +56,7 @@ class WebDriver:
         )
 
     # TODO: Handle horizontal scrolling
-    def screenshots_png(self):
+    def scroll_and_screenshot(self):
         tops = []
         images = []
         dims = self.driver.execute_script(
@@ -69,15 +69,22 @@ class WebDriver:
         view_height = dims["vh"]
         doc_height = dims["dh"]
 
-        self.driver.execute_script("window.scroll(0, 0)")
-        while True:
+        try:
+            self.driver.execute_script("window.scroll(0, 0)")
             curr = self.driver.execute_script("return window.scrollY")
-            tops.append(curr)
-            images.append(self.driver.get_screenshot_as_png())
-            if curr + view_height < doc_height:
-                curr = self.driver.execute_script(f"window.scroll(0, {curr+view_height})")
-            else:
-                break
+
+            while True:
+                tops.append(curr)
+                images.append(self.driver.get_screenshot_as_png())
+                if curr + view_height < doc_height:
+                    self.driver.execute_script(f"window.scroll(0, {curr+view_height})")
+
+                curr = self.driver.execute_script("return window.scrollY")
+                if curr <= tops[-1]:
+                    break
+        finally:
+            # Reset scroll to the top of the page
+            self.driver.execute_script("window.scroll(0, 0)")
 
         return tops, images
 

--- a/src/docquery/web.py
+++ b/src/docquery/web.py
@@ -14,10 +14,10 @@ try:
     from selenium import webdriver
     from selenium.webdriver.chrome.options import Options
     from webdriver_manager.chrome import ChromeDriverManager
+    from webdriver_manager.core.utils import ChromeType
 
     WEB_AVAILABLE = True
-except ImportError as e:
-    log.warning("%s" % (e))
+except ImportError:
     WEB_AVAILABLE = False
 
 
@@ -30,8 +30,7 @@ class WebDriver:
     def __init__(self):
         if not WEB_AVAILABLE:
             raise ValueError(
-                "Web imports are unavailable. You must install the [web] extra and a version of"
-                " chromedriver_py compatible with your system"
+                "Web imports are unavailable. You must install the [web] extra and chrome or" " chromium system-wide."
             )
 
         options = Options()
@@ -40,7 +39,9 @@ class WebDriver:
         if os.geteuid() == 0:
             options.add_argument("--no-sandbox")
 
-        self.driver = webdriver.Chrome(options=options, executable_path=ChromeDriverManager().install())
+        self.driver = webdriver.Chrome(
+            options=options, executable_path=ChromeDriverManager(chrome_type=ChromeType.CHROMIUM).install()
+        )
 
     def get(self, page):
         self.driver.get(page)

--- a/src/docquery/web.py
+++ b/src/docquery/web.py
@@ -1,33 +1,69 @@
 import os
 from pathlib import Path
 
-from chromedriver_py import binary_path  # This library allows you to download the driver for your version of chrome
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-from selenium.webdriver.common.by import By
+from .config import get_logger
+
+
+log = get_logger("web")
+
+try:
+    from chromedriver_py import binary_path  # This library allows you to download the driver for your version of chrome
+    from selenium import webdriver
+    from selenium.webdriver.chrome.options import Options
+
+    WEB_AVAILABLE = True
+except ImportError as e:
+    log.warning("%s" % (e))
+    WEB_AVAILABLE = False
 
 
 FIND_LEAF_NODES_JS = None
+WEB_DRIVER = None
 dir_path = Path(os.path.dirname(os.path.realpath(__file__)))
 
 
-def get_webdriver():
-    options = Options()
-    options.headless = True
-    options.add_argument("--window-size=1920,1200")
-
-    return webdriver.Chrome(options=options, executable_path=binary_path)
-
-
-def find_word_boxes(driver):
-    global FIND_LEAF_NODES_JS
-    if FIND_LEAF_NODES_JS is None:
-        with open(dir_path / "find_leaf_nodes.js", "r") as f:
-            FIND_LEAF_NODES_JS = (
-                f.read()
-                + """
-                return computeBoundingBoxes(document.body);
-            """
+class WebDriver:
+    def __init__(self):
+        if not WEB_AVAILABLE:
+            raise ValueError(
+                "Web imports are unavailable. You must install the [web] extra and a version of"
+                " chromedriver_py compatible with your system"
             )
-    # Assumes the driver has been pointed at the right website already
-    return driver.execute_script(FIND_LEAF_NODES_JS)
+
+        options = Options()
+        options.headless = True
+        options.add_argument("--window-size=1920,1200")
+
+        self.driver = webdriver.Chrome(options=options, executable_path=binary_path)
+
+    def get(self, page):
+        self.driver.get(page)
+
+    def get_html(self, html):
+        # https://stackoverflow.com/questions/22538457/put-a-string-with-html-javascript-into-selenium-webdriver
+        self.driver.get("data:text/html;charset=utf-8," + html)
+
+    def find_word_boxes(self):
+        global FIND_LEAF_NODES_JS
+        if FIND_LEAF_NODES_JS is None:
+            with open(dir_path / "find_leaf_nodes.js", "r") as f:
+                FIND_LEAF_NODES_JS = (
+                    f.read()
+                    + """
+                    return computeBoundingBoxes(document.body);
+                """
+                )
+        # Assumes the driver has been pointed at the right website already
+        return self.driver.execute_script(FIND_LEAF_NODES_JS)
+
+    def screenshots_png(self):
+        # TODO: I think this will only return the first "pane" as a screenshot. We should probably adjust
+        # the horizontal size and scroll vertically to generate multiple previews
+        return [self.driver.get_screenshot_as_png()]
+
+
+def get_webdriver():
+    global WEB_DRIVER
+    if WEB_DRIVER is None:
+        WEB_DRIVER = WebDriver()
+    return WEB_DRIVER

--- a/src/docquery/web.py
+++ b/src/docquery/web.py
@@ -37,6 +37,8 @@ class WebDriver:
         options = Options()
         options.headless = True
         options.add_argument("--window-size=1920,1200")
+        if os.geteuid() == 0:
+            options.add_argument("--no-sandbox")
 
         self.driver = webdriver.Chrome(options=options, executable_path=ChromeDriverManager().install())
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -71,6 +71,31 @@ EXAMPLES = [
             }
         ],
     ),
+    Example(
+        name="readme",
+        path="https://github.com/impira/docquery/blob/ef73fa7e8069773ace03efae2254f3a510a814ef/README.md",
+        qa_pairs=[
+            {
+                "question": "What are the use cases for DocQuery?",
+                "answers": {
+                    # These examples demonstrate the fact that the "word_boxes" are way too coarse in the web document implementation
+                    "LayoutLMv1": {
+                        "score": 0.6288,
+                        "answer": "DocQuery is a library and command-line tool that makes it easy to analyze semi-structured and unstructured documents (PDFs, scanned images, etc.) using large language models (LLMs). You simply point DocQuery at one or more documents and specify a question you want to ask. DocQuery is created by the team at Impira.",
+                        "word_ids": [43],
+                        "page": 0,
+                    },
+                    "LayoutLMv1-Invoices": {
+                        "score": 0.9136,
+                        "answer": "DocQuery is a library and command-line tool that makes it easy to analyze semi-structured and unstructured documents (PDFs, scanned images, etc.) using large language models (LLMs). You simply point DocQuery at one or more documents and specify a question you want to ask. DocQuery is created by the team at Impira.",
+                        "word_ids": [43],
+                        "page": 0,
+                    },
+                    "Donut": {"answer": "engine Powered by large language"},
+                },
+            }
+        ],
+    ),
 ]
 
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -80,13 +80,13 @@ EXAMPLES = [
                 "answers": {
                     # These examples demonstrate the fact that the "word_boxes" are way too coarse in the web document implementation
                     "LayoutLMv1": {
-                        "score": 0.6288,
-                        "answer": "DocQuery is a library and command-line tool that makes it easy to analyze semi-structured and unstructured documents (PDFs, scanned images, etc.) using large language models (LLMs). You simply point DocQuery at one or more documents and specify a question you want to ask. DocQuery is created by the team at Impira.",
-                        "word_ids": [43],
-                        "page": 0,
+                        "score": 0.7728,
+                        "answer": "DocQuery excels at a number of use cases involving structured, semi-structured, or unstructured documents. You can ask questions about invoices, contracts, forms, emails, letters, receipts, and many more. You can also classify documents. We will continue evolving the model, offer more modeling options, and expanding the set of supported documents. We welcome feedback, requests, and of course contributions to help achieve this vision.",
+                        "word_ids": [7],
+                        "page": 1,
                     },
                     "LayoutLMv1-Invoices": {
-                        "score": 0.9136,
+                        "score": 0.7931,
                         "answer": "DocQuery is a library and command-line tool that makes it easy to analyze semi-structured and unstructured documents (PDFs, scanned images, etc.) using large language models (LLMs). You simply point DocQuery at one or more documents and specify a question you want to ask. DocQuery is created by the team at Impira.",
                         "word_ids": [43],
                         "page": 0,

--- a/tests/test_web_driver.py
+++ b/tests/test_web_driver.py
@@ -1,0 +1,23 @@
+from docquery.web import get_webdriver
+
+
+def test_singleton():
+    d1 = get_webdriver()
+    d2 = get_webdriver()
+    assert d1 is d2, "Both webdrivers should map to the same instance"
+
+
+def test_readme_file():
+    driver = get_webdriver()
+    driver.get("https://github.com/impira/docquery/blob/ef73fa7e8069773ace03efae2254f3a510a814ef/README.md")
+    word_boxes = driver.find_word_boxes()
+
+    # This sanity checks the logic that merges word boxes
+    assert len(word_boxes["word_boxes"]) > 20, "Expect multiple word boxes"
+
+    # Make sure the last screenshot is shorter than the previous ones
+    _, screenshots = driver.scroll_and_screenshot()
+    assert len(screenshots) > 1, "Expect multiple pages"
+    assert (
+        screenshots[0].size[1] - screenshots[-1].size[1] > 10
+    ), "Expect the last page to be shorter than the first several"


### PR DESCRIPTION
This change adds the basics required to support scraping:

- A web.py package that wraps selenium/chromium and can extract screenshots
- Javascript code (find_leaf_nodes.js) that finds all leaf nodes with words in an HTML document. This is in JS specifically so that we can reuse it for other use cases (e.g. a Chrome plugin) where the text gets extracted client-side
- A new `WebDocument` class (+ a bit of supportive refactoring) that wraps the web driver
- Tests + documentation