### PR TITLE
Some refactoring to match transformers DocumentQuestionAnsweringPipeline

### DIFF
--- a/src/docquery/ext/pipeline_document_question_answering.py
+++ b/src/docquery/ext/pipeline_document_question_answering.py
@@ -465,7 +465,7 @@ class DocumentQuestionAnsweringPipeline(ChunkPipeline):
                     predicted_token_classes = (
                         output["token_logits"][
                             0,
-                            start : eend + 1,
+                            start : end + 1,
                         ]
                         .argmax(axis=1)
                         .cpu()

--- a/src/docquery/transformers_patch.py
+++ b/src/docquery/transformers_patch.py
@@ -98,17 +98,20 @@ def pipeline(
     # be a clever way to get around this. Either way, we should be able to remove it once
     # https://github.com/huggingface/transformers/commit/5c4c869014f5839d04c1fd28133045df0c91fd84
     # is officially released.
-    config = AutoConfig.from_pretrained(model, revision=revision)
+    config = AutoConfig.from_pretrained(model, revision=revision, **{**pipeline_kwargs})
 
     if tokenizer is None:
         tokenizer = AutoTokenizer.from_pretrained(
             model,
             revision=revision,
             config=config,
+            **pipeline_kwargs,
         )
 
     if any(a == "LayoutLMForQuestionAnswering" for a in config.architectures):
-        model = LayoutLMForQuestionAnswering.from_pretrained(model, config=config, revision=revision)
+        model = LayoutLMForQuestionAnswering.from_pretrained(
+            model, config=config, revision=revision, **{**pipeline_kwargs}
+        )
 
     if config.model_type == "vision-encoder-decoder":
         # This _should_ be a feature of transformers -- deriving the feature_extractor automatically --
@@ -120,6 +123,7 @@ def pipeline(
         # available, which at the time of writing is not a feature of transformers
         device = 0 if torch.cuda.is_available() else -1
 
+    breakpoint()
     return transformers_pipeline(
         task,
         revision=revision,

--- a/src/docquery/transformers_patch.py
+++ b/src/docquery/transformers_patch.py
@@ -123,7 +123,6 @@ def pipeline(
         # available, which at the time of writing is not a feature of transformers
         device = 0 if torch.cuda.is_available() else -1
 
-    breakpoint()
     return transformers_pipeline(
         task,
         revision=revision,

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -18,7 +18,7 @@ CHECKPOINTS = {
 
 class QAPair(BaseModel):
     question: str
-    answers: Dict[str, Dict]
+    answers: Dict[str, List[Dict]]
 
 
 class Example(BaseModel):
@@ -36,9 +36,11 @@ EXAMPLES = [
             {
                 "question": "What is the purchase amount?",
                 "answers": {
-                    "LayoutLMv1": {"score": 0.9999, "answer": "$1,000,000,000", "word_ids": [97], "page": 0},
-                    "LayoutLMv1-Invoices": {"score": 0.9997, "answer": "$1,000,000,000", "word_ids": [97], "page": 0},
-                    "Donut": {"answer": "$1,0000,000,00"},
+                    "LayoutLMv1": [{"score": 0.9999, "answer": "$1,000,000,000", "word_ids": [97], "page": 0}],
+                    "LayoutLMv1-Invoices": [
+                        {"score": 0.9997, "answer": "$1,000,000,000", "word_ids": [97], "page": 0}
+                    ],
+                    "Donut": [{"answer": "$1,0000,000,00"}],
                 },
             }
         ],
@@ -50,9 +52,9 @@ EXAMPLES = [
             {
                 "question": "What is the invoice number?",
                 "answers": {
-                    "LayoutLMv1": {"score": 0.9997, "answer": "us-001", "word_ids": [15], "page": 0},
-                    "LayoutLMv1-Invoices": {"score": 0.9999, "answer": "us-001", "word_ids": [15], "page": 0},
-                    "Donut": {"answer": "us-001"},
+                    "LayoutLMv1": [{"score": 0.9997, "answer": "us-001", "word_ids": [15], "page": 0}],
+                    "LayoutLMv1-Invoices": [{"score": 0.9999, "answer": "us-001", "word_ids": [15], "page": 0}],
+                    "Donut": [{"answer": "us-001"}],
                 },
             }
         ],
@@ -64,9 +66,9 @@ EXAMPLES = [
             {
                 "question": "What are net sales for 2020?",
                 "answers": {
-                    "LayoutLMv1": {"score": 0.9429, "answer": "$ 3,750\n", "word_ids": [15, 16], "page": 0},
-                    "LayoutLMv1-Invoices": {"score": 0.9956, "answer": "$ 3,750\n", "word_ids": [15, 16], "page": 0},
-                    "Donut": {"answer": "$ 3,750"},
+                    "LayoutLMv1": [{"score": 0.9429, "answer": "$ 3,750\n", "word_ids": [15, 16], "page": 0}],
+                    "LayoutLMv1-Invoices": [{"score": 0.9956, "answer": "$ 3,750\n", "word_ids": [15, 16], "page": 0}],
+                    "Donut": [{"answer": "$ 3,750"}],
                 },
             }
         ],
@@ -79,19 +81,23 @@ EXAMPLES = [
                 "question": "What are the use cases for DocQuery?",
                 "answers": {
                     # These examples demonstrate the fact that the "word_boxes" are way too coarse in the web document implementation
-                    "LayoutLMv1": {
-                        "score": 0.9921,
-                        "answer": "DocQuery is a swiss army knife tool for working with documents and experiencing the power of modern machine learning. You can use it\njust about anywhere, including behind a firewall on sensitive data, and test it with a wide variety of documents. Our hope is that\nDocQuery enables many creative use cases for document understanding by making it simple and easy to ask questions from your documents.",
-                        "word_ids": [37],
-                        "page": 2,
-                    },
-                    "LayoutLMv1-Invoices": {
-                        "score": 0.9939,
-                        "answer": "DocQuery is a library and command-line tool that makes it easy to analyze semi-structured and unstructured documents (PDFs, scanned\nimages, etc.) using large language models (LLMs). You simply point DocQuery at one or more documents and specify a\nquestion you want to ask. DocQuery is created by the team at ",
-                        "word_ids": [98],
-                        "page": 0,
-                    },
-                    "Donut": {"answer": "engine Powered by large language"},
+                    "LayoutLMv1": [
+                        {
+                            "score": 0.9921,
+                            "answer": "DocQuery is a swiss army knife tool for working with documents and experiencing the power of modern machine learning. You can use it\njust about anywhere, including behind a firewall on sensitive data, and test it with a wide variety of documents. Our hope is that\nDocQuery enables many creative use cases for document understanding by making it simple and easy to ask questions from your documents.",
+                            "word_ids": [37],
+                            "page": 2,
+                        }
+                    ],
+                    "LayoutLMv1-Invoices": [
+                        {
+                            "score": 0.9939,
+                            "answer": "DocQuery is a library and command-line tool that makes it easy to analyze semi-structured and unstructured documents (PDFs, scanned\nimages, etc.) using large language models (LLMs). You simply point DocQuery at one or more documents and specify a\nquestion you want to ask. DocQuery is created by the team at ",
+                            "word_ids": [98],
+                            "page": 0,
+                        }
+                    ],
+                    "Donut": [{"answer": "engine Powered by large language"}],
                 },
             }
         ],


### PR DESCRIPTION
I made some changes before landing the `DocumentQuestionAnsweringPipeline` in transformers. Now that we're upstreaming some more changes to transformers, I wanted to reconcile the two pipelines. The only remaining difference is how we accept inputs (an array of images) and process multiple pages.