### PR TITLE
Add `max_num_spans` (that defaults to `1`)

### DIFF
--- a/src/docquery/ext/pipeline_document_classification.py
+++ b/src/docquery/ext/pipeline_document_classification.py
@@ -95,6 +95,7 @@ class DocumentClassificationPipeline(ChunkPipeline):
         doc_stride=None,
         lang: Optional[str] = None,
         tesseract_config: Optional[str] = None,
+        max_num_spans: Optional[int] = None,
         max_seq_len=None,
         function_to_apply=None,
         top_k=None,
@@ -108,6 +109,8 @@ class DocumentClassificationPipeline(ChunkPipeline):
             preprocess_params["lang"] = lang
         if tesseract_config is not None:
             preprocess_params["tesseract_config"] = tesseract_config
+        if max_num_spans is not None:
+            preprocess_params["max_num_spans"] = max_num_spans
 
         if isinstance(function_to_apply, str):
             function_to_apply = ClassificationFunction[function_to_apply.upper()]

--- a/src/docquery/ext/pipeline_document_classification.py
+++ b/src/docquery/ext/pipeline_document_classification.py
@@ -143,6 +143,7 @@ class DocumentClassificationPipeline(ChunkPipeline):
         word_boxes: Tuple[str, List[float]] = None,
         lang=None,
         tesseract_config="",
+        max_num_spans=1,
     ):
         # NOTE: This code mirrors the code in question answering and will be implemented in a follow up PR
         # to support documents with enough tokens that overflow the model's window
@@ -153,6 +154,8 @@ class DocumentClassificationPipeline(ChunkPipeline):
 
         if doc_stride is None:
             doc_stride = min(max_seq_len // 2, 256)
+
+        total_num_spans = 0
 
         for page_idx, (image, word_boxes) in enumerate(input["pages"]):
             image_features = {}
@@ -252,6 +255,10 @@ class DocumentClassificationPipeline(ChunkPipeline):
                         **span_encoding,
                         "page": page_idx,
                     }
+
+                    total_num_spans += 1
+                    if total_num_spans >= max_num_spans:
+                        break
 
     def _forward(self, model_inputs):
         page = model_inputs.pop("page", None)


### PR DESCRIPTION
This PR gives the caller of the classification pipeline the ability to limit the number of spans used to build up the classification probabilities. This is useful, for example, to limit classification to the first span in the first page (the default with `max_num_spans=1`).