### PR TITLE
Add `--ignore-embedded-text`

### DIFF
--- a/src/docquery/cmd/scan.py
+++ b/src/docquery/cmd/scan.py
@@ -28,6 +28,12 @@ def build_parser(subparsers, parent_parser):
         "--ocr", choices=list(OCR_MAPPING.keys()), default=None, help="The OCR engine you would like to use"
     )
     parser.add_argument(
+        "--ignore-embedded-text",
+        dest="use_embedded_text",
+        action="store_false",
+        help="Do not try and extract embedded text from document types that might provide it (e.g. PDFs)",
+    )
+    parser.add_argument(
         "--classify",
         default=False,
         action="store_true",
@@ -59,7 +65,7 @@ def main(args):
     docs = []
     for p in paths:
         try:
-            docs.append((p, load_document(str(p), ocr_reader=args.ocr)))
+            docs.append((p, load_document(str(p), ocr_reader=args.ocr, use_embedded_text=args.use_embedded_text)))
             log.info(f"Loading {p}")
         except UnsupportedDocument as e:
             log.warning(f"Cannot load {p}: {e}. Skipping...")

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -67,6 +67,11 @@ EXAMPLES = [
                 "question": "What are net sales for 2020?",
                 "answers": {
                     "LayoutLMv1": [{"score": 0.9429, "answer": "$ 3,750\n", "word_ids": [15, 16], "page": 0}],
+                    # (The answer with `use_embedded_text=False` relies entirely on Tesseract, and it is incorrect because it
+                    # misses 3,750 altogether.)
+                    "LayoutLMv1-use_embedded_text=False": [
+                        {"score": 0.3078, "answer": "$ 3,980", "word_ids": [11, 12], "page": 0}
+                    ],
                     "LayoutLMv1-Invoices": [{"score": 0.9956, "answer": "$ 3,750\n", "word_ids": [15, 16], "page": 0}],
                     "Donut": [{"answer": "$ 3,750"}],
                 },
@@ -132,3 +137,12 @@ def test_run_with_choosen_OCR_instance():
     for qa in example.qa_pairs:
         resp = pipe(question=qa.question, **document.context, top_k=1)
         assert nested_simplify(resp, decimals=4) == qa.answers["LayoutLMv1"]
+
+
+def test_run_with_ignore_embedded_text():
+    example = EXAMPLES[2]
+    document = load_document(example.path, use_embedded_text=False)
+    pipe = pipeline("document-question-answering", model=CHECKPOINTS["LayoutLMv1"])
+    for qa in example.qa_pairs:
+        resp = pipe(question=qa.question, **document.context, top_k=1)
+        assert nested_simplify(resp, decimals=4) == qa.answers["LayoutLMv1-use_embedded_text=False"]

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -69,7 +69,7 @@ EXAMPLES = [
                     "LayoutLMv1": [{"score": 0.9429, "answer": "$ 3,750\n", "word_ids": [15, 16], "page": 0}],
                     # (The answer with `use_embedded_text=False` relies entirely on Tesseract, and it is incorrect because it
                     # misses 3,750 altogether.)
-                    "LayoutLMv1-use_embedded_text=False": [
+                    "LayoutLMv1__use_embedded_text=False": [
                         {"score": 0.3078, "answer": "$ 3,980", "word_ids": [11, 12], "page": 0}
                     ],
                     "LayoutLMv1-Invoices": [{"score": 0.9956, "answer": "$ 3,750\n", "word_ids": [15, 16], "page": 0}],
@@ -145,4 +145,4 @@ def test_run_with_ignore_embedded_text():
     pipe = pipeline("document-question-answering", model=CHECKPOINTS["LayoutLMv1"])
     for qa in example.qa_pairs:
         resp = pipe(question=qa.question, **document.context, top_k=1)
-        assert nested_simplify(resp, decimals=4) == qa.answers["LayoutLMv1-use_embedded_text=False"]
+        assert nested_simplify(resp, decimals=4) == qa.answers["LayoutLMv1__use_embedded_text=False"]


### PR DESCRIPTION
This PR adds the `--ignore-embedded-text` flag to the `scan` command so that it is possible to ignore embedded text in document types that support it (e.g. PDFs). The motivation for this feature is that some PDFs have OCR results embedded that are low quality and should be ignored.

The addition to `load_document` is tested via:

```
pytest -sv tests/test_end_to_end.py::test_run_with_ignore_embedded_text
```

Notably, the answer with Tesseract only is actually incorrect, because it _seems_ Tesseract is missing entire columns. The detected words are included below for completeness.

---

```
level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	text
1	1	0	0	0	0	0	0	2984	2017	-1	
2	1	1	0	0	0	983	117	1051	270	-1	
3	1	1	1	0	0	983	117	1051	270	-1	
4	1	1	1	1	0	1089	117	848	81	-1	
5	1	1	1	1	1	1089	120	339	78	96.375221	Example
5	1	1	1	1	2	1455	117	482	81	96.375221	Corporation
4	1	1	1	2	0	1144	222	740	62	-1	
5	1	1	1	2	1	1144	223	293	61	95.583748	Income
5	1	1	1	2	2	1463	222	421	62	95.908981	Statement
4	1	1	1	3	0	983	325	1051	62	-1	
5	1	1	1	3	1	983	326	225	61	96.508057	Years
5	1	1	1	3	2	1233	326	249	61	94.502167	ended
5	1	1	1	3	3	1512	326	415	61	95.726517	December
5	1	1	1	3	4	1953	325	81	62	96.705353	31
2	1	2	0	0	0	110	622	1944	1076	-1	
3	1	2	1	0	0	110	622	1944	1076	-1	
4	1	2	1	1	0	1853	622	169	67	-1	
5	1	2	1	1	1	1853	622	169	67	95.815376	2021
4	1	2	1	2	0	112	733	1942	71	-1	
5	1	2	1	2	1	112	739	113	53	96.800400	Net
5	1	2	1	2	2	252	739	168	54	96.709694	sales
5	1	2	1	2	3	1797	733	38	65	90.889954	$
5	1	2	1	2	4	1865	738	189	66	96.346062	3,980
4	1	2	1	3	0	110	837	1944	67	-1	
5	1	2	1	3	1	110	838	152	54	96.828300	Cost
5	1	2	1	3	2	289	837	64	55	96.456902	of
5	1	2	1	3	3	379	839	168	54	96.827141	sales
5	1	2	1	3	4	1882	838	172	66	96.470360	3,100
4	1	2	1	4	0	191	937	1863	69	-1	
5	1	2	1	4	1	191	938	190	54	96.490280	Gross
5	1	2	1	4	2	411	937	173	69	96.649429	profit
5	1	2	1	4	3	1929	938	125	54	96.423843	880
4	1	2	1	5	0	110	1038	1944	69	-1	
5	1	2	1	5	1	110	1038	236	69	95.381752	Selling,
5	1	2	1	5	2	376	1039	245	68	95.381752	general
5	1	2	1	5	3	651	1039	118	54	96.037506	and
5	1	2	1	5	4	799	1038	473	55	96.281448	administrative
5	1	2	1	5	5	1300	1052	318	54	96.281448	expenses
5	1	2	1	5	6	1926	1038	128	54	96.353394	640
4	1	2	1	6	0	191	1138	1863	69	-1	
5	1	2	1	6	1	191	1138	329	69	95.168625	Operating
5	1	2	1	6	2	550	1138	239	54	95.168625	income
5	1	2	1	6	3	1930	1138	124	54	96.681396	240
4	1	2	1	7	0	112	1238	1942	68	-1	
5	1	2	1	7	1	112	1239	251	53	95.475174	Interest
5	1	2	1	7	2	390	1252	281	54	95.890358	expense
5	1	2	1	7	3	1975	1238	79	54	96.899559	20
4	1	2	1	8	0	112	1337	1942	69	-1	
5	1	2	1	8	1	112	1339	149	53	96.832222	Loss
5	1	2	1	8	2	289	1352	76	40	95.149628	on
5	1	2	1	8	3	395	1339	130	54	95.149628	sale
5	1	2	1	8	4	552	1337	65	55	96.685936	of
5	1	2	1	8	5	642	1338	355	68	96.013023	equipment
5	1	2	1	8	6	2020	1339	34	53	46.738262	3
4	1	2	1	9	0	193	1437	1861	56	-1	
5	1	2	1	9	1	193	1439	240	53	95.960945	Income
5	1	2	1	9	2	463	1437	212	55	96.558929	before
5	1	2	1	9	3	703	1438	240	54	96.434120	income
5	1	2	1	9	4	969	1443	179	50	96.526375	taxes
5	1	2	1	9	5	1943	1438	111	54	95.162476	215
4	1	2	1	10	0	112	1538	1942	68	-1	
5	1	2	1	10	1	112	1539	239	53	96.232224	Income
5	1	2	1	10	2	378	1543	100	50	96.777534	tax
5	1	2	1	10	3	505	1552	281	54	96.775764	expense
5	1	2	1	10	4	1975	1538	79	54	60.813385	90
4	1	2	1	11	0	193	1633	1861	65	-1	
5	1	2	1	11	1	193	1639	113	53	96.561966	Net
5	1	2	1	11	2	334	1638	240	54	96.537872	income
5	1	2	1	11	3	1813	1633	37	65	92.767982	$
5	1	2	1	11	4	1940	1638	114	54	86.674126	165
2	1	3	0	0	0	987	1831	1083	48	-1	
3	1	3	1	0	0	987	1831	1083	48	-1	
4	1	3	1	1	0	987	1831	1083	48	-1	
5	1	3	1	1	1	987	1833	104	46	94.757164	See
5	1	3	1	1	2	1116	1836	153	42	94.760239	notes
5	1	3	1	1	3	1291	1836	54	42	94.760239	to
5	1	3	1	1	4	1367	1833	90	45	96.529266	the
5	1	3	1	1	5	1478	1831	234	48	96.207291	financial
5	1	3	1	1	6	1737	1836	333	43	95.699104	statements.
2	1	4	0	0	0	2614	1633	242	65	-1	
3	1	4	1	0	0	2614	1633	242	65	-1	
4	1	4	1	1	0	2614	1633	242	65	-1	
5	1	4	1	1	1	2614	1633	38	65	93.202171	$
5	1	4	1	1	2	2742	1638	114	54	88.240753	135
```